### PR TITLE
Adds "ignore" properties capability

### DIFF
--- a/source/FastDeepCloner/ClonerShared.cs
+++ b/source/FastDeepCloner/ClonerShared.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace FastDeepCloner
 {
@@ -12,21 +11,32 @@ namespace FastDeepCloner
     {
         private readonly SafeValueType<string, object> _alreadyCloned = new SafeValueType<string, object>();
         private readonly FastDeepClonerSettings _settings;
+        private readonly ICollection<PropertyInfo> _ignoredPropertyInfos;
+
+        internal ClonerShared(ICollection<PropertyInfo> ignoredPropertyInfos, FieldType fieldType) : this(fieldType)
+        {
+            _ignoredPropertyInfos = ignoredPropertyInfos;
+        }
+
+        internal ClonerShared(ICollection<PropertyInfo> ignoredPropertyInfos, FastDeepClonerSettings settings) : this(settings)
+        {
+            _ignoredPropertyInfos = ignoredPropertyInfos;
+        }
 
         internal ClonerShared(FieldType fieldType)
         {
-            _settings = new FastDeepClonerSettings() { FieldType = fieldType };
-
+            _settings = new FastDeepClonerSettings {FieldType = fieldType};
         }
 
         internal ClonerShared(FastDeepClonerSettings settings)
         {
             if (settings != null)
                 _settings = settings;
-            else _settings = new FastDeepClonerSettings() { FieldType = FieldType.PropertyInfo };
+            else _settings = new FastDeepClonerSettings() {FieldType = FieldType.PropertyInfo};
         }
 
-        private object ReferenceTypeClone(Dictionary<string, IFastDeepClonerProperty> properties, Type primaryType, object objectToBeCloned, object appendToValue = null)
+        private object ReferenceTypeClone(Dictionary<string, IFastDeepClonerProperty> properties, Type primaryType,
+            object objectToBeCloned, object appendToValue = null)
         {
             var identifier = objectToBeCloned.GetFastDeepClonerIdentifier();
             if (identifier != null && _alreadyCloned.ContainsKey(identifier))
@@ -57,13 +67,14 @@ namespace FastDeepCloner
 
             return resObject;
         }
+
         internal object Clone(object objectToBeCloned)
         {
             if (objectToBeCloned == null)
                 return null;
             var primaryType = objectToBeCloned.GetType();
             if (primaryType.IsArray && primaryType.GetArrayRank() > 1)
-                return ((Array)objectToBeCloned).Clone();
+                return ((Array) objectToBeCloned).Clone();
 
             if (objectToBeCloned.IsInternalObject())
                 return objectToBeCloned;
@@ -71,18 +82,21 @@ namespace FastDeepCloner
             object resObject;
             if (primaryType.IsArray || (objectToBeCloned as IList) != null)
             {
-                resObject = primaryType.IsArray ? Array.CreateInstance(primaryType.GetIListType(), (objectToBeCloned as Array).Length) : Activator.CreateInstance(primaryType.GetIListType());
+                resObject = primaryType.IsArray
+                    ? Array.CreateInstance(primaryType.GetIListType(), ((Array) objectToBeCloned).Length)
+                    : Activator.CreateInstance(primaryType.GetIListType());
                 var i = 0;
                 var ilist = resObject as IList;
                 var array = resObject as Array;
 
-                foreach (var item in (objectToBeCloned as IList))
+                foreach (var item in ((IList) objectToBeCloned))
                 {
                     object clonedIteam = null;
                     if (item != null)
                     {
                         clonedIteam = item.GetType().IsInternalType() ? item : Clone(item);
                     }
+
                     if (!primaryType.IsArray)
                         ilist?.Add(clonedIteam);
                     else
@@ -90,7 +104,9 @@ namespace FastDeepCloner
                     i++;
                 }
 
-                foreach (var prop in FastDeepClonerCachedItems.GetFastDeepClonerProperties(primaryType).Where(x => !FastDeepClonerCachedItems.GetFastDeepClonerProperties(typeof(List<string>)).Any(a => a.Key == x.Key)))
+                foreach (var prop in primaryType.GetFastDeepClonerProperties(_ignoredPropertyInfos).Where(x =>
+                    FastDeepClonerCachedItems.GetFastDeepClonerProperties(typeof(List<string>))
+                        .All(a => a.Key != x.Key)))
                 {
                     var property = prop.Value;
                     if (!property.CanRead || property.FastDeepClonerIgnore)
@@ -106,7 +122,7 @@ namespace FastDeepCloner
             {
                 resObject = Activator.CreateInstance(primaryType);
                 var resDic = resObject as IDictionary;
-                var dictionary = (IDictionary)objectToBeCloned;
+                var dictionary = (IDictionary) objectToBeCloned;
                 foreach (var key in dictionary.Keys)
                 {
                     var item = dictionary[key];
@@ -115,32 +131,41 @@ namespace FastDeepCloner
                     {
                         clonedIteam = item.GetType().IsInternalType() ? item : Clone(item);
                     }
+
                     resDic?.Add(key, clonedIteam);
                 }
             }
             else if (primaryType.IsAnonymousType()) // dynamic types
             {
-
-                var props = FastDeepClonerCachedItems.GetFastDeepClonerProperties(primaryType);
+                var props = primaryType.GetFastDeepClonerProperties(_ignoredPropertyInfos);
                 resObject = new ExpandoObject();
                 var d = resObject as IDictionary<string, object>;
                 foreach (var prop in props.Values)
                 {
                     var item = prop.GetValue(objectToBeCloned);
-                    var value = item == null || prop.IsInternalType || (item?.IsInternalObject() ?? true) ? item : Clone(item);
+                    var value = item == null || prop.IsInternalType || (item?.IsInternalObject() ?? true)
+                        ? item
+                        : Clone(item);
                     if (!d.ContainsKey(prop.Name))
                         d.Add(prop.Name, value);
                 }
             }
             else
             {
-                resObject = ReferenceTypeClone((_settings.FieldType == FieldType.FieldInfo ? FastDeepClonerCachedItems.GetFastDeepClonerFields(primaryType) : FastDeepClonerCachedItems.GetFastDeepClonerProperties(primaryType)), primaryType, objectToBeCloned);
+                resObject = ReferenceTypeClone(
+                    (_settings.FieldType == FieldType.FieldInfo
+                        ? FastDeepClonerCachedItems.GetFastDeepClonerFields(primaryType)
+                        : primaryType.GetFastDeepClonerProperties(_ignoredPropertyInfos)), primaryType,
+                    objectToBeCloned);
                 if (_settings.FieldType == FieldType.Both)
-                    resObject = ReferenceTypeClone(FastDeepClonerCachedItems.GetFastDeepClonerFields(primaryType).Values.ToList().Where(x => !FastDeepClonerCachedItems.GetFastDeepClonerProperties(primaryType).ContainsKey(x.Name)).ToDictionary(x => x.Name, x => x), primaryType, objectToBeCloned, resObject);
+                    resObject = ReferenceTypeClone(
+                        FastDeepClonerCachedItems.GetFastDeepClonerFields(primaryType).Values.ToList()
+                            .Where(x => !primaryType.GetFastDeepClonerProperties(_ignoredPropertyInfos)
+                                .ContainsKey(x.Name)).ToDictionary(x => x.Name, x => x), primaryType, objectToBeCloned,
+                        resObject);
             }
 
             return resObject;
         }
-
     }
 }

--- a/source/FastDeepCloner/Extensions.cs
+++ b/source/FastDeepCloner/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace FastDeepCloner
@@ -83,6 +84,11 @@ namespace FastDeepCloner
         public static bool IsInternalType(this Type underlyingSystemType)
         {
             return (TypeDict.ContainsKey(underlyingSystemType) || !underlyingSystemType.GetTypeInfo().IsClass) && !underlyingSystemType.GetTypeInfo().IsInterface;
+        }
+
+        internal static bool None<T>(this IEnumerable<T> enumerable)
+        {
+            return !enumerable.Any();
         }
     }
 }

--- a/source/FastDeepCloner/FastDeepCloner.csproj
+++ b/source/FastDeepCloner/FastDeepCloner.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net451;netstandard2.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net451;netstandard2.0</TargetFrameworks>
     <Version>1.2.4</Version>
     <AssemblyVersion>1.0.2.4</AssemblyVersion>
     <FileVersion>1.0.2.4</FileVersion>


### PR DESCRIPTION
This makes usages such as these possible:

```csharp
var cloned = user.Clone(ignoredProperties: i => i.Name);
```

This will not clone the property `Name` while copying the objects.